### PR TITLE
Updated SDP subarray image to 0.5.15

### DIFF
--- a/charts/sdp-prototype/templates/sdp-devices-deploy.yml
+++ b/charts/sdp-prototype/templates/sdp-devices-deploy.yml
@@ -87,7 +87,7 @@ spec:
           value: "0"
         - name: SDP_CONFIG_HOST
           value: {{ include "sdp-prototype.etcd-host" . }}
-        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.12
+        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.15
         imagePullPolicy: Always
         resources: {}
 


### PR DESCRIPTION
- Updated the SDP Subarray image to 0.5.15.
- Updated Pytango version to 9.3.1.
- Updated CONFIGURE command.
- This image has the ability to create multiple SDP subarrays.