### PR TITLE
Updated subarray devices and TANGO version

### DIFF
--- a/charts/sdp-prototype/data/sdp-devices.json
+++ b/charts/sdp-prototype/data/sdp-devices.json
@@ -1,8 +1,8 @@
 {
     "servers": {
-        "SdpMaster": {
+        "SDPMaster": {
             "1": {
-                "SdpMaster": {
+                "SDPMaster": {
                     "mid_sdp/elt/master": {
                         "attribute_properties": {
                             "healthState": {
@@ -27,9 +27,9 @@
                 }
             }
         },
-        "SdpSubarray": {
+        "SDPSubarray": {
             "1": {
-                "SdpSubarray": {
+                "SDPSubarray": {
                     "mid_sdp/elt/subarray_1": {
                         "attribute_properties": {
                             "adminMode": {
@@ -39,6 +39,12 @@
                                 ]
                             },
                             "healthState": {
+                                "abs_change": [
+                                    "-1",
+                                    "1"
+                                ]
+                            },
+                            "obsMode": {
                                 "abs_change": [
                                     "-1",
                                     "1"
@@ -57,9 +63,6 @@
                             }
                         },
                         "properties": {
-                            "Version": [
-                                "0.5.8"
-                            ],
                             "SkaLevel": [
                                 "2"
                             ],
@@ -73,7 +76,69 @@
                                 "obsstate",
                                 "1000",
                                 "receiveaddresses",
-                                "1000"
+                                "1000",
+                                "activeprocessingblocks",
+                                "1000",
+                                "testmode",
+                                "2000"
+                            ]
+                        }
+                    }
+                }
+            },
+            "2": {
+                "SDPSubarray": {
+                    "mid_sdp/elt/subarray_2": {
+                        "attribute_properties": {
+                            "adminMode": {
+                                "abs_change": [
+                                    "-1",
+                                    "1"
+                                ]
+                            },
+                            "healthState": {
+                                "abs_change": [
+                                    "-1",
+                                    "1"
+                                ]
+                            },
+                            "obsMode": {
+                                "abs_change": [
+                                    "-1",
+                                    "1"
+                                ]
+                            },
+                            "obsState": {
+                                "abs_change": [
+                                    "-1",
+                                    "1"
+                                ]
+                            },
+                            "storageLoggingLevel": {
+                                "__value": [
+                                    "5"
+                                ]
+                            }
+                        },
+                        "properties": {
+                            "SkaLevel": [
+                                "2"
+                            ],
+                            "polled_attr": [
+                                "adminmode",
+                                "1000",
+                                "healthstate",
+                                "1000",
+                                "obsmode",
+                                "1000",
+                                "obsstate",
+                                "1000",
+                                "receiveaddresses",
+                                "1000",
+                                "activeprocessingblocks",
+                                "1000",
+                                "testmode",
+                                "2000"
                             ]
                         }
                     }

--- a/charts/sdp-prototype/templates/sdp-devices-deploy.yml
+++ b/charts/sdp-prototype/templates/sdp-devices-deploy.yml
@@ -87,7 +87,7 @@ spec:
           value: "0"
         - name: SDP_CONFIG_HOST
           value: {{ include "sdp-prototype.etcd-host" . }}
-        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.12
+        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.15
         imagePullPolicy: Always
         resources: {}
 

--- a/charts/sdp-prototype/templates/sdp-devices-deploy.yml
+++ b/charts/sdp-prototype/templates/sdp-devices-deploy.yml
@@ -74,10 +74,10 @@ spec:
         env:
         - name: TANGO_HOST
           value: databaseds-tango-base-{{ .Release.Name }}:10000
-        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_master:0.2.1
+        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_master:0.2.3
         imagePullPolicy: Always
         resources: {}
-      - name: sdp-subarray
+      - name: sdp-subarray-1
         env:
         - name: TANGO_HOST
           value: databaseds-tango-base-{{ .Release.Name }}:10000
@@ -85,9 +85,28 @@ spec:
           value: "0"
         - name: TOGGLE_CBF_OUTPUT_LINK
           value: "0"
+        - name: TOGGLE_AUTO_REGISTER
+          value: "0"
         - name: SDP_CONFIG_HOST
           value: {{ include "sdp-prototype.etcd-host" . }}
-        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.15
+        args: ["1", "-v4"]
+        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.16
+        imagePullPolicy: Always
+        resources: {}
+      - name: sdp-subarray-2
+        env:
+        - name: TANGO_HOST
+          value: databaseds-tango-base-{{ .Release.Name }}:10000
+        - name: TOGGLE_CONFIG_DB
+          value: "0"
+        - name: TOGGLE_CBF_OUTPUT_LINK
+          value: "0"
+        - name: TOGGLE_AUTO_REGISTER
+          value: "0"
+        - name: SDP_CONFIG_HOST
+          value: {{ include "sdp-prototype.etcd-host" . }}
+        args: ["2", "-v4"]
+        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.16
         imagePullPolicy: Always
         resources: {}
 


### PR DESCRIPTION
Updated SDPSubarray - It creates 2 servers and 2 devices
Updated TANGO version to TANGO 9.3.3rc
New Images for:
SDP Master - nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_master:0.2.3
SDP Subarray - nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.16 