### PR TITLE
Sdp integration - Update TMC, CSP, OET, SDP image versions

### DIFF
--- a/charts/csp-proto/templates/csplmc.yaml
+++ b/charts/csp-proto/templates/csplmc.yaml
@@ -78,7 +78,8 @@ spec:
     args:
       - -c
       - "sudo ln -sf /logs/log /dev/log && \
-            retry --max=20 -- tango_admin --ping-device mid_csp/elt/master &&\
+            retry --max=10 -- tango_admin --ping-device mid_csp/elt/master &&\
+            retry --max=10 -- tango_admin --ping-device mid_csp_cbf/sub_elt/subarray_01 &&\
             /venv/bin/python /app/csplmc/CspSubarray/CspSubarray/CspSubarray.py sub1"
     env:
     - name: TANGO_HOST
@@ -99,6 +100,10 @@ spec:
             retry --max=10 -- tango_admin --ping-device mid_csp_cbf/vcc/002 &&\
             retry --max=10 -- tango_admin --ping-device mid_csp_cbf/vcc/003 &&\
             retry --max=10 -- tango_admin --ping-device mid_csp_cbf/vcc/004 &&\
+            retry --max=10 -- tango_admin --ping-device mid_csp_cbf/fsp/01 &&\
+            retry --max=10 -- tango_admin --ping-device mid_csp_cbf/fsp/02 &&\
+            retry --max=10 -- tango_admin --ping-device mid_csp_cbf/fsp/03 &&\
+            retry --max=10 -- tango_admin --ping-device mid_csp_cbf/fsp/04 &&\
             /venv/bin/python /app/tangods/CbfMaster/CbfMaster/CbfMaster.py master"
     env:
     - name: TANGO_HOST
@@ -115,6 +120,7 @@ spec:
     args:
       - -c
       - "sudo ln -sf /logs/log /dev/log && \
+            retry --max=5 -- tango_admin --ping-device mid_csp_cbf/sub_elt/master &&\
             /venv/bin/python /app/tangods/CbfSubarray/CbfSubarrayMulti/CbfSubarrayMulti.py cbfSubarray-01"
     env:
     - name: TANGO_HOST

--- a/charts/csp-proto/values.yaml
+++ b/charts/csp-proto/values.yaml
@@ -19,7 +19,7 @@ csplmc:
     registry: nexus.engageska-portugal.pt/ska-docker
     image: csplmc
     tag: 0.1.4
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 midcbfmcs:
   enabled: true
@@ -27,7 +27,7 @@ midcbfmcs:
     registry: nexus.engageska-portugal.pt/ska-docker
     image: mid-cbf-mcs
     tag: 0.1.2
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 dsconfig:
   image:

--- a/charts/csp-proto/values.yaml
+++ b/charts/csp-proto/values.yaml
@@ -18,7 +18,7 @@ csplmc:
   image:
     registry: nexus.engageska-portugal.pt/ska-docker
     image: csplmc
-    tag: 0.1.0
+    tag: 0.1.4
     pullPolicy: Always
 
 midcbfmcs:
@@ -26,7 +26,7 @@ midcbfmcs:
   image:
     registry: nexus.engageska-portugal.pt/ska-docker
     image: mid-cbf-mcs
-    tag: 0.1.0
+    tag: 0.1.2
     pullPolicy: Always
 
 dsconfig:

--- a/charts/oet/values.yaml
+++ b/charts/oet/values.yaml
@@ -10,7 +10,7 @@ oet:
   image:
     registry: nexus.engageska-portugal.pt/ska-telescope
     image: oet-ssh
-    tag: 0.2.8
+    tag: 0.2.9
     pullPolicy: Always
 
 nodeSelector: {}

--- a/charts/oet/values.yaml
+++ b/charts/oet/values.yaml
@@ -11,7 +11,7 @@ oet:
     registry: nexus.engageska-portugal.pt/ska-telescope
     image: oet-ssh
     tag: 0.2.9
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 nodeSelector: {}
 

--- a/charts/sdp-prototype/templates/sdp-devices-deploy.yml
+++ b/charts/sdp-prototype/templates/sdp-devices-deploy.yml
@@ -74,7 +74,7 @@ spec:
         env:
         - name: TANGO_HOST
           value: databaseds-tango-base-{{ .Release.Name }}:10000
-        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_master:0.2.1
+        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_master:0.2.3
         imagePullPolicy: Always
         resources: {}
       - name: sdp-subarray
@@ -87,7 +87,7 @@ spec:
           value: "0"
         - name: SDP_CONFIG_HOST
           value: {{ include "sdp-prototype.etcd-host" . }}
-        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.12
+        image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.16
         imagePullPolicy: Always
         resources: {}
 

--- a/charts/sdp-prototype/templates/sdp-devices-deploy.yml
+++ b/charts/sdp-prototype/templates/sdp-devices-deploy.yml
@@ -75,7 +75,7 @@ spec:
         - name: TANGO_HOST
           value: databaseds-tango-base-{{ .Release.Name }}:10000
         image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_master:0.2.3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources: {}
       - name: sdp-subarray
         env:
@@ -88,6 +88,6 @@ spec:
         - name: SDP_CONFIG_HOST
           value: {{ include "sdp-prototype.etcd-host" . }}
         image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.16
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources: {}
 

--- a/charts/tmc-proto/values.yaml
+++ b/charts/tmc-proto/values.yaml
@@ -19,7 +19,7 @@ tmcprototype:
     registry: nexus.engageska-portugal.pt/tango-example
     image: tmcprototype
     tag: 0.1.3
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 tmalarmhandler:
   enabled: true

--- a/charts/tmc-proto/values.yaml
+++ b/charts/tmc-proto/values.yaml
@@ -18,7 +18,7 @@ tmcprototype:
   image:
     registry: nexus.engageska-portugal.pt/tango-example
     image: tmcprototype
-    tag: latest
+    tag: 0.1.3
     pullPolicy: Always
 
 tmalarmhandler:


### PR DESCRIPTION
1. Update TMC, CSP, OET and SDP image versions which have support for latest PyTango and Tango images.
2. To resolve some issues in CSP devices, added ping statements for dependant devices as suggested by Elisabetta. 